### PR TITLE
fix: remove old naming references to react-router-breadcrumbs-hoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Justin Schrader <me@justin.beer>",
   "license": "MIT",
   "private": false,
+  "types": "types/use-react-router-breadcrumbs/index.d.ts",
   "peerDependencies": {
     "react": ">=16.8",
     "react-router": ">=5.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-react-router-breadcrumbs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A hook for displaying and setting breadcrumbs for react router",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,7 +39,7 @@ export default exports.map((item) => ({
     exports: 'named',
     file: item.file,
     format: item.format,
-    name: 'react-router-breadcrumbs-hoc',
+    name: 'use-react-router-breadcrumbs',
     globals,
     sourcemap: true,
   },

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -150,7 +150,7 @@ components.BreadcrumbExtraPropsTest.propTypes = {
   bar: PropTypes.string.isRequired,
 };
 
-describe('react-router-breadcrumbs-hoc', () => {
+describe('use-react-router-breadcrumbs', () => {
   describe('Valid routes', () => {
     it('Should render breadcrumb components as expected', () => {
       const routes = [


### PR DESCRIPTION
Fixes #3 