### PR TITLE
Support React Router v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-react-router-breadcrumbs",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "A hook for displaying and setting breadcrumbs for react router",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "types": "dist/index.d.ts",
   "peerDependencies": {
     "react": ">=16.8",
-    "react-router": ">=5.1.0"
+    "react-router": ">=6.0.0"
   },
   "scripts": {
     "prepublishOnly": "yarn build && pinst --disable",
@@ -36,7 +36,6 @@
     "@rollup/plugin-typescript": "^8.2.1",
     "@types/react": "^17.0.11",
     "@types/react-dom": "^17.0.7",
-    "@types/react-router": "^5.1.15",
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.1",
@@ -55,7 +54,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router": "^5.2.0",
+    "react-router": "^6.0.0",
     "rollup": "^2.51.1",
     "rollup-plugin-size": "^0.2.2",
     "rollup-plugin-terser": "^7.0.2",
@@ -66,6 +65,6 @@
     "router",
     "breadcrumbs",
     "react-router",
-    "react-router 5"
+    "react-router 6"
   ]
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -212,6 +212,30 @@ describe('use-react-router-breadcrumbs', () => {
       const { breadcrumbs } = render({ pathname: '/user/create', routes });
       expect(breadcrumbs).toBe('Root / User / Add User');
     });
+
+    it('Should match the correct breadcrumb in route if they have the same score', () => {
+      const routes = [
+        {
+          path: 'user/*',
+          breadcrumb: 'User',
+          children: [{ index: true, breadcrumb: 'Hello' }],
+        },
+        {
+          path: 'user/:pid',
+          children: [{ path: '*', breadcrumb: 'World' }],
+        },
+        {
+          path: 'user/create',
+          breadcrumb: 'First Create',
+        },
+        {
+          path: 'user/create',
+          breadcrumb: 'Last Create',
+        },
+      ];
+      const { breadcrumbs } = render({ pathname: '/user/create/x', routes });
+      expect(breadcrumbs).toBe('Home / User / First Create / World');
+    });
   });
 
   describe('Different component types', () => {
@@ -300,6 +324,17 @@ describe('use-react-router-breadcrumbs', () => {
       ];
       const { breadcrumbs } = render({ pathname: '/one', routes });
       expect(breadcrumbs).toBe('Home / Parent');
+    });
+
+    it('Should use the default breadcrumb If neither the index route nor the parent route provide breadcrumb', () => {
+      const routes = [
+        {
+          path: 'one',
+          children: [{ index: true }],
+        },
+      ];
+      const { breadcrumbs } = render({ pathname: '/one', routes });
+      expect(breadcrumbs).toBe('Home / One');
     });
   });
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -46,7 +46,7 @@ const components = {
     );
   },
   BreadcrumbMatchTest: ({ match }) => <span>{match.params.number}</span>,
-  BreadcrumbNavLinkTest: ({ match }) => <a to={match.url}>Link</a>,
+  BreadcrumbNavLinkTest: ({ match }) => <a to={match.pathname}>Link</a>,
   BreadcrumbLocationTest: ({
     location: {
       state: { isLocationTest },
@@ -115,10 +115,9 @@ const render = ({ options, pathname, routes, state, props }) => {
 };
 
 const matchShape = {
-  isExact: PropTypes.bool.isRequired,
   params: PropTypes.shape().isRequired,
-  path: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
+  pathname: PropTypes.string.isRequired,
+  pattern: PropTypes.object.isRequired,
 };
 
 components.Breadcrumbs.propTypes = {
@@ -128,14 +127,24 @@ components.Breadcrumbs.propTypes = {
     disableDefaults: PropTypes.bool,
   }),
   routes: PropTypes.arrayOf(
-    PropTypes.shape({
-      path: PropTypes.string.isRequired,
-      breadcrumb: PropTypes.oneOfType([
-        PropTypes.node,
-        PropTypes.func,
-        PropTypes.object,
-      ]),
-    }),
+    PropTypes.oneOfType([
+      PropTypes.shape({
+        path: PropTypes.string.isRequired,
+        breadcrumb: PropTypes.oneOfType([
+          PropTypes.node,
+          PropTypes.func,
+          PropTypes.object,
+        ]),
+      }),
+      PropTypes.shape({
+        index: PropTypes.bool.isRequired,
+        breadcrumb: PropTypes.oneOfType([
+          PropTypes.node,
+          PropTypes.func,
+          PropTypes.object,
+        ]),
+      }),
+    ]),
   ),
 };
 
@@ -182,44 +191,26 @@ describe('use-react-router-breadcrumbs', () => {
           path: '/1/2/:number/4',
           breadcrumb: components.BreadcrumbNavLinkTest,
         },
-        // test a no-match route
-        { path: '/no-match', breadcrumb: 'no match' },
+        // test a `*` route
+        { path: '*', breadcrumb: 'Any' },
       ];
-      const { breadcrumbs, wrapper } = render({ pathname: '/1/2/3/4', routes });
-      expect(breadcrumbs).toBe('Home / One / TWO / 3 / Link');
+      const { breadcrumbs, wrapper } = render({ pathname: '/1/2/3/4/5', routes });
+      expect(breadcrumbs).toBe('Home / One / TWO / 3 / Link / Any');
       expect(wrapper.find('a').props().to).toBe('/1/2/3/4');
     });
   });
 
   describe('Route order', () => {
-    it('Should match the first breadcrumb in route array user/create', () => {
+    it('Should intelligently match the more suitable breadcrumb in route array user/create', () => {
       const routes = [
-        {
-          path: '/user/create',
-          breadcrumb: 'Add User',
-        },
-        {
-          path: '/user/:id',
-          breadcrumb: '1',
-        },
+        { path: '/', breadcrumb: 'Home' },
+        // index has higher score
+        { index: true, breadcrumb: 'Root' },
+        { path: '/user/:id', breadcrumb: '1' },
+        { path: '/user/create', breadcrumb: 'Add User' },
       ];
       const { breadcrumbs } = render({ pathname: '/user/create', routes });
-      expect(breadcrumbs).toBe('Home / User / Add User');
-    });
-
-    it('Should match the first breadcrumb in route array user/:id', () => {
-      const routes = [
-        {
-          path: '/user/:id',
-          breadcrumb: 'Oops',
-        },
-        {
-          path: '/user/create',
-          breadcrumb: 'Add User',
-        },
-      ];
-      const { breadcrumbs } = render({ pathname: '/user/create', routes });
-      expect(breadcrumbs).toBe('Home / User / Oops');
+      expect(breadcrumbs).toBe('Root / User / Add User');
     });
   });
 
@@ -242,17 +233,16 @@ describe('use-react-router-breadcrumbs', () => {
   });
 
   describe('Custom match options', () => {
-    it('Should allow `strict` rule', () => {
+    it('Should allow `caseSensitive` rule', () => {
       const routes = [
         {
-          path: '/one/',
+          path: '/one',
           breadcrumb: '1',
-          // not recommended, but supported
-          matchOptions: { exact: false, strict: true },
+          caseSensitive: true,
         },
       ];
-      const { breadcrumbs } = render({ pathname: '/one', routes });
-      expect(breadcrumbs).toBe('');
+      const { breadcrumbs } = render({ pathname: '/OnE', routes });
+      expect(breadcrumbs).toBe('Home / OnE');
     });
   });
 
@@ -270,17 +260,46 @@ describe('use-react-router-breadcrumbs', () => {
       const routes = [
         {
           path: '/one',
-          routes: [
+          children: [
             {
               path: '/one/two',
               breadcrumb: 'TwoCustom',
-              routes: [{ path: '/one/two/three', breadcrumb: 'ThreeCustom' }],
+              children: [{ path: '/one/two/three', breadcrumb: 'ThreeCustom' }],
             },
           ],
         },
       ];
       const { breadcrumbs } = render({ pathname: '/one/two/three', routes });
       expect(breadcrumbs).toBe('Home / One / TwoCustom / ThreeCustom');
+    });
+
+    it('Should support nested routes with relative path', () => {
+      const routes = [
+        {
+          path: 'one',
+          children: [
+            {
+              path: 'two',
+              breadcrumb: 'TwoCustom',
+              children: [{ path: 'three', breadcrumb: 'ThreeCustom' }],
+            },
+          ],
+        },
+      ];
+      const { breadcrumbs } = render({ pathname: '/one/two/three', routes });
+      expect(breadcrumbs).toBe('Home / One / TwoCustom / ThreeCustom');
+    });
+
+    it('Should use the breadcrumb provided by parent if the index route dose not provide one', () => {
+      const routes = [
+        {
+          path: 'one',
+          breadcrumb: 'Parent',
+          children: [{ index: true }],
+        },
+      ];
+      const { breadcrumbs } = render({ pathname: '/one', routes });
+      expect(breadcrumbs).toBe('Home / Parent');
     });
   });
 
@@ -418,12 +437,39 @@ describe('use-react-router-breadcrumbs', () => {
   });
 
   describe('Invalid route object', () => {
-    it('Should error if `path` is not provided', () => {
+    it('Should error if `path` or `index` is not provided', () => {
       expect(() => getMethod()({
         routes: [{ breadcrumb: 'Yo' }],
         location: { pathname: '/1' },
       })).toThrow(
-        'useBreadcrumbs: `path` must be provided in every route object',
+        'useBreadcrumbs: `path` or `index` must be provided in every route object',
+      );
+    });
+
+    it('Should error if both `path` and `index` are provided', () => {
+      expect(() => getMethod()({
+        routes: [{ index: true, path: '/', breadcrumb: 'Yo' }],
+        location: { pathname: '/1' },
+      })).toThrow(
+        'useBreadcrumbs: `path` and `index` cannot be provided at the same time',
+      );
+    });
+
+    it('Should not support nested absolute paths', () => {
+      expect(() => getMethod()({
+        routes: [{ path: '/a', breadcrumb: 'Yo', children: [{ path: '/b' }] }],
+        location: { pathname: '/1' },
+      })).toThrow(
+        'useBreadcrumbs: The absolute path of the child route must start with the parent path',
+      );
+    });
+
+    it('Should error If the index route provides children', () => {
+      expect(() => getMethod()({
+        routes: [{ index: true, breadcrumb: 'Yo', children: [{ path: '/b' }] }],
+        location: { pathname: '/1' },
+      })).toThrow(
+        'useBreadcrumbs: Index route cannot have child routes',
       );
     });
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,67 +26,67 @@ import {
   PathPattern,
 } from 'react-router';
 
- type Location = ReturnType<typeof useLocation>;
+type Location = ReturnType<typeof useLocation>;
 
 export interface Options {
-   disableDefaults?: boolean;
-   excludePaths?: string[];
- }
+  disableDefaults?: boolean;
+  excludePaths?: string[];
+}
 
 export interface BreadcrumbMatch<ParamKey extends string = string> {
-   /**
-    * The names and values of dynamic parameters in the URL.
-    */
-   params: Params<ParamKey>;
-   /**
-    * The portion of the URL pathname that was matched.
-    */
-   pathname: string;
-   /**
-    * The pattern that was used to match.
-    */
-   pattern: PathPattern;
-   /**
-    * The route object that was used to match.
-    */
-   route?: BreadcrumbsRoute;
- }
+  /**
+   * The names and values of dynamic parameters in the URL.
+   */
+  params: Params<ParamKey>;
+  /**
+   * The portion of the URL pathname that was matched.
+   */
+  pathname: string;
+  /**
+   * The pattern that was used to match.
+   */
+  pattern: PathPattern;
+  /**
+   * The route object that was used to match.
+   */
+  route?: BreadcrumbsRoute;
+}
 
 export interface BreadcrumbComponentProps<ParamKey extends string = string> {
-   key: string;
-   match: BreadcrumbMatch<ParamKey>;
-   location: Location;
- }
+  key: string;
+  match: BreadcrumbMatch<ParamKey>;
+  location: Location;
+}
 
 export type BreadcrumbComponentType<ParamKey extends string = string> =
-   React.ComponentType<BreadcrumbComponentProps<ParamKey>>;
+  React.ComponentType<BreadcrumbComponentProps<ParamKey>>;
 
 export interface BreadcrumbsRoute<ParamKey extends string = string>
-   extends RouteObject {
-   children?: BreadcrumbsRoute[];
-   breadcrumb?: BreadcrumbComponentType<ParamKey> | string | null;
-   props?: { [x: string]: unknown };
- }
+  extends RouteObject {
+  children?: BreadcrumbsRoute[];
+  breadcrumb?: BreadcrumbComponentType<ParamKey> | string | null;
+  props?: { [x: string]: unknown };
+}
 
 export interface BreadcrumbData<ParamKey extends string = string> {
-   match: BreadcrumbMatch<ParamKey>;
-   location: Location;
-   key: string;
-   breadcrumb: React.ReactNode;
- }
+  match: BreadcrumbMatch<ParamKey>;
+  location: Location;
+  key: string;
+  breadcrumb: React.ReactNode;
+}
 
- // The code below is modified from React Router
- interface BreadcrumbsRouteMeta {
-   relativePath: string;
-   childrenIndex: number;
-   route: BreadcrumbsRoute;
- }
+// The code below is modified from React Router
+interface BreadcrumbsRouteMeta {
+  relativePath: string;
+  childrenIndex: number;
+  route: BreadcrumbsRoute;
+}
 
- interface BreadcrumbsRouteBranch {
-   path: string;
-   score: number;
-   routesMeta: BreadcrumbsRouteMeta[];
- }
+interface BreadcrumbsRouteBranch {
+  path: string;
+  score: number;
+  routesMeta: BreadcrumbsRouteMeta[];
+}
 
 const joinPaths = (paths: string[]): string => paths.join('/').replace(/\/\/+/g, '/');
 
@@ -193,30 +193,30 @@ function rankRouteBranches(
 const NO_BREADCRUMB = Symbol('NO_BREADCRUMB');
 
 /**
-  * This method was "borrowed" from https://stackoverflow.com/a/28339742
-  * we used to use the humanize-string package, but it added a lot of bundle
-  * size and issues with compilation. This 4-liner seems to cover most cases.
-  */
+ * This method was "borrowed" from https://stackoverflow.com/a/28339742
+ * we used to use the humanize-string package, but it added a lot of bundle
+ * size and issues with compilation. This 4-liner seems to cover most cases.
+ */
 const humanize = (str: string): string => str
   .replace(/^[\s_]+|[\s_]+$/g, '')
   .replace(/[_\s]+/g, ' ')
   .replace(/^[a-z]/, (m) => m.toUpperCase());
 
 /**
-  * Renders and returns the breadcrumb complete
-  * with `match`, `location`, and `key` props.
-  */
+ * Renders and returns the breadcrumb complete
+ * with `match`, `location`, and `key` props.
+ */
 const render = ({
   breadcrumb: Breadcrumb,
   match,
   location,
   props,
 }: {
-   breadcrumb: BreadcrumbComponentType | string;
-   match: BreadcrumbMatch;
-   location: Location;
-   props?: { [x: string]: unknown };
- }): BreadcrumbData => {
+  breadcrumb: BreadcrumbComponentType | string;
+  match: BreadcrumbMatch;
+  location: Location;
+  props?: { [x: string]: unknown };
+}): BreadcrumbData => {
   const componentProps = {
     match,
     location,
@@ -227,26 +227,26 @@ const render = ({
   return {
     ...componentProps,
     breadcrumb:
-       typeof Breadcrumb === 'string' ? (
-         createElement('span', { key: componentProps.key }, Breadcrumb)
-       ) : (
-         <Breadcrumb {...componentProps} />
-       ),
+      typeof Breadcrumb === 'string' ? (
+        createElement('span', { key: componentProps.key }, Breadcrumb)
+      ) : (
+        <Breadcrumb {...componentProps} />
+      ),
   };
 };
 
 /**
-  * Small helper method to get a default breadcrumb if the user hasn't provided one.
-  */
+ * Small helper method to get a default breadcrumb if the user hasn't provided one.
+ */
 const getDefaultBreadcrumb = ({
   currentSection,
   location,
   pathSection,
 }: {
-   currentSection: string;
-   location: Location;
-   pathSection: string;
- }): BreadcrumbData => {
+  currentSection: string;
+  location: Location;
+  pathSection: string;
+}): BreadcrumbData => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const match = matchPath(
     {
@@ -264,9 +264,9 @@ const getDefaultBreadcrumb = ({
 };
 
 /**
-  * Loops through the route array (if provided) and returns either a
-  * user-provided breadcrumb OR a sensible default (if enabled)
-  */
+ * Loops through the route array (if provided) and returns either a
+ * user-provided breadcrumb OR a sensible default (if enabled)
+ */
 const getBreadcrumbMatch = ({
   currentSection,
   disableDefaults,
@@ -275,13 +275,13 @@ const getBreadcrumbMatch = ({
   pathSection,
   branches,
 }: {
-   currentSection: string;
-   disableDefaults?: boolean;
-   excludePaths?: string[];
-   location: Location;
-   pathSection: string;
-   branches: BreadcrumbsRouteBranch[];
- }): typeof NO_BREADCRUMB | BreadcrumbData => {
+  currentSection: string;
+  disableDefaults?: boolean;
+  excludePaths?: string[];
+  location: Location;
+  pathSection: string;
+  branches: BreadcrumbsRouteBranch[];
+}): typeof NO_BREADCRUMB | BreadcrumbData => {
   let breadcrumb: BreadcrumbData | typeof NO_BREADCRUMB | undefined;
 
   // Check the optional `excludePaths` option in `options` to see if the
@@ -372,18 +372,18 @@ const getBreadcrumbMatch = ({
 };
 
 /**
-  * Splits the pathname into sections, then search for matches in the routes
-  * a user-provided breadcrumb OR a sensible default.
-  */
+ * Splits the pathname into sections, then search for matches in the routes
+ * a user-provided breadcrumb OR a sensible default.
+ */
 export const getBreadcrumbs = ({
   routes,
   location,
   options = {},
 }: {
-   routes: BreadcrumbsRoute[];
-   location: Location;
-   options?: Options;
- }): BreadcrumbData[] => {
+  routes: BreadcrumbsRoute[];
+  location: Location;
+  options?: Options;
+}): BreadcrumbData[] => {
   const { pathname } = location;
 
   const branches = rankRouteBranches(flattenRoutes(routes));
@@ -429,8 +429,8 @@ export const getBreadcrumbs = ({
 };
 
 /**
-  * Default hook function export.
-  */
+ * Default hook function export.
+ */
 const useReactRouterBreadcrumbs = (
   routes?: BreadcrumbsRoute[],
   options?: Options,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,102 +17,244 @@
  * https://github.com/icd2k3/use-react-router-breadcrumbs
  *
  */
-
 import React, { createElement } from 'react';
-import { matchPath, useLocation } from 'react-router';
+import {
+  matchPath,
+  useLocation,
+  RouteObject,
+  Params,
+  PathPattern,
+} from 'react-router';
 
-type Location = ReturnType<typeof useLocation>;
+ type Location = ReturnType<typeof useLocation>;
 
 export interface Options {
-  disableDefaults?: boolean;
-  excludePaths?: string[];
+   disableDefaults?: boolean;
+   excludePaths?: string[];
+ }
+
+export interface BreadcrumbMatch<ParamKey extends string = string> {
+   /**
+    * The names and values of dynamic parameters in the URL.
+    */
+   params: Params<ParamKey>;
+   /**
+    * The portion of the URL pathname that was matched.
+    */
+   pathname: string;
+   /**
+    * The pattern that was used to match.
+    */
+   pattern: PathPattern;
+   /**
+    * The route object that was used to match.
+    */
+   route?: BreadcrumbsRoute;
+ }
+
+export interface BreadcrumbComponentProps<ParamKey extends string = string> {
+   key: string;
+   match: BreadcrumbMatch<ParamKey>;
+   location: Location;
+ }
+
+export type BreadcrumbComponentType<ParamKey extends string = string> =
+   React.ComponentType<BreadcrumbComponentProps<ParamKey>>;
+
+export interface BreadcrumbsRoute<ParamKey extends string = string>
+   extends RouteObject {
+   children?: BreadcrumbsRoute[];
+   breadcrumb?: BreadcrumbComponentType<ParamKey> | string | null;
+   props?: { [x: string]: unknown };
+ }
+
+export interface BreadcrumbData<ParamKey extends string = string> {
+   match: BreadcrumbMatch<ParamKey>;
+   location: Location;
+   key: string;
+   breadcrumb: React.ReactNode;
+ }
+
+ // The code below is modified from React Router
+ interface BreadcrumbsRouteMeta {
+   relativePath: string;
+   childrenIndex: number;
+   route: BreadcrumbsRoute;
+ }
+
+ interface BreadcrumbsRouteBranch {
+   path: string;
+   score: number;
+   routesMeta: BreadcrumbsRouteMeta[];
+ }
+
+const joinPaths = (paths: string[]): string => paths.join('/').replace(/\/\/+/g, '/');
+
+const paramRe = /^:\w+$/;
+const dynamicSegmentValue = 3;
+const indexRouteValue = 2;
+const emptySegmentValue = 1;
+const staticSegmentValue = 10;
+const splatPenalty = -2;
+const isSplat = (s: string) => s === '*';
+
+function computeScore(path: string, index: boolean | undefined): number {
+  const segments = path.split('/');
+  let initialScore = segments.length;
+  if (segments.some(isSplat)) {
+    initialScore += splatPenalty;
+  }
+
+  if (index) {
+    initialScore += indexRouteValue;
+  }
+
+  return segments
+    .filter((s) => !isSplat(s))
+    .reduce((score, segment) => {
+      if (paramRe.test(segment)) {
+        return score + dynamicSegmentValue;
+      }
+      if (segment === '') {
+        return score + emptySegmentValue;
+      }
+      return score + staticSegmentValue;
+    }, initialScore);
 }
 
-export interface MatchOptions {
-  exact?: boolean;
-  strict?: boolean;
-  sensitive?: boolean;
+function compareIndexes(a: number[], b: number[]): number {
+  const siblings = a.length === b.length && a.slice(0, -1).every((n, i) => n === b[i]);
+  return siblings ? a[a.length - 1] - b[b.length - 1] : 0;
 }
 
-export interface BreadcrumbsRoute {
-  path: string;
-  breadcrumb?: React.ComponentType | React.ElementType | string | null;
-  matchOptions?: MatchOptions;
-  routes?: BreadcrumbsRoute[];
-  props?: { [x: string]: unknown };
+function flattenRoutes(
+  routes: BreadcrumbsRoute[],
+  branches: BreadcrumbsRouteBranch[] = [],
+  parentsMeta: BreadcrumbsRouteMeta[] = [],
+  parentPath = '',
+): BreadcrumbsRouteBranch[] {
+  routes.forEach((route, index) => {
+    if (!route.path && !route.index) {
+      throw new Error(
+        'useBreadcrumbs: `path` or `index` must be provided in every route object',
+      );
+    }
+    if (route.path && route.index) {
+      throw new Error(
+        'useBreadcrumbs: `path` and `index` cannot be provided at the same time',
+      );
+    }
+    const meta: BreadcrumbsRouteMeta = {
+      relativePath: route.path || '',
+      childrenIndex: index,
+      route,
+    };
+
+    if (meta.relativePath.charAt(0) === '/') {
+      if (!meta.relativePath.startsWith(parentPath)) {
+        throw new Error(
+          'useBreadcrumbs: The absolute path of the child route must start with the parent path',
+        );
+      }
+      meta.relativePath = meta.relativePath.slice(parentPath.length);
+    }
+
+    const path = joinPaths([parentPath, meta.relativePath]);
+    const routesMeta = parentsMeta.concat(meta);
+
+    if (route.children && route.children.length > 0) {
+      if (route.index) {
+        throw new Error('useBreadcrumbs: Index route cannot have child routes');
+      }
+      flattenRoutes(route.children, branches, routesMeta, path);
+    }
+
+    branches.push({
+      path,
+      score: computeScore(path, route.index),
+      routesMeta,
+    });
+  });
+  return branches;
 }
 
-export interface BreadcrumbData {
-  match: { url: string };
-  location: Location;
-  key: string;
-  breadcrumb: React.ReactNode;
+function rankRouteBranches(
+  branches: BreadcrumbsRouteBranch[],
+): BreadcrumbsRouteBranch[] {
+  return branches.sort((a, b) => (a.score !== b.score
+    ? b.score - a.score // Higher score first
+    : compareIndexes(
+      a.routesMeta.map((meta) => meta.childrenIndex),
+      b.routesMeta.map((meta) => meta.childrenIndex),
+    )));
 }
 
-const DEFAULT_MATCH_OPTIONS = { exact: true };
-const NO_BREADCRUMB = 'NO_BREADCRUMB';
+// Begin: useBreadcrumbs
+const NO_BREADCRUMB = Symbol('NO_BREADCRUMB');
 
 /**
- * This method was "borrowed" from https://stackoverflow.com/a/28339742
- * we used to use the humanize-string package, but it added a lot of bundle
- * size and issues with compilation. This 4-liner seems to cover most cases.
- */
+  * This method was "borrowed" from https://stackoverflow.com/a/28339742
+  * we used to use the humanize-string package, but it added a lot of bundle
+  * size and issues with compilation. This 4-liner seems to cover most cases.
+  */
 const humanize = (str: string): string => str
   .replace(/^[\s_]+|[\s_]+$/g, '')
   .replace(/[_\s]+/g, ' ')
   .replace(/^[a-z]/, (m) => m.toUpperCase());
 
 /**
- * Renders and returns the breadcrumb complete
- * with `match`, `location`, and `key` props.
- */
+  * Renders and returns the breadcrumb complete
+  * with `match`, `location`, and `key` props.
+  */
 const render = ({
   breadcrumb: Breadcrumb,
   match,
   location,
   props,
 }: {
-  breadcrumb: React.ComponentType | string;
-  match: { url: string };
-  location: Location;
-  props?: { [x: string]: unknown };
-}): BreadcrumbData => {
+   breadcrumb: BreadcrumbComponentType | string;
+   match: BreadcrumbMatch;
+   location: Location;
+   props?: { [x: string]: unknown };
+ }): BreadcrumbData => {
   const componentProps = {
     match,
     location,
-    key: match.url,
+    key: match.pathname,
     ...(props || {}),
   };
 
   return {
     ...componentProps,
     breadcrumb:
-      typeof Breadcrumb === 'string' ? (
-        createElement('span', { key: componentProps.key }, Breadcrumb)
-      ) : (
-        <Breadcrumb {...componentProps} />
-      ),
+       typeof Breadcrumb === 'string' ? (
+         createElement('span', { key: componentProps.key }, Breadcrumb)
+       ) : (
+         <Breadcrumb {...componentProps} />
+       ),
   };
 };
 
 /**
- * Small helper method to get a default breadcrumb if the user hasn't provided one.
- */
+  * Small helper method to get a default breadcrumb if the user hasn't provided one.
+  */
 const getDefaultBreadcrumb = ({
   currentSection,
   location,
   pathSection,
 }: {
-  currentSection: string;
-  location: Location;
-  pathSection: string;
-}): BreadcrumbData => {
-  const match = matchPath(pathSection, {
-    ...DEFAULT_MATCH_OPTIONS,
-    path: pathSection,
-  }) /* istanbul ignore next: this is hard to mock in jest :( */ || {
-    url: 'not-found',
-  };
+   currentSection: string;
+   location: Location;
+   pathSection: string;
+ }): BreadcrumbData => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const match = matchPath(
+    {
+      end: true,
+      path: pathSection,
+    },
+    pathSection,
+  )!;
 
   return render({
     breadcrumb: humanize(currentSection),
@@ -122,86 +264,93 @@ const getDefaultBreadcrumb = ({
 };
 
 /**
- * Loops through the route array (if provided) and returns either a
- * user-provided breadcrumb OR a sensible default (if enabled)
- */
+  * Loops through the route array (if provided) and returns either a
+  * user-provided breadcrumb OR a sensible default (if enabled)
+  */
 const getBreadcrumbMatch = ({
   currentSection,
   disableDefaults,
   excludePaths,
   location,
   pathSection,
-  routes,
+  branches,
 }: {
-  currentSection: string;
-  disableDefaults?: boolean;
-  excludePaths?: string[];
-  location: Location;
-  pathSection: string;
-  routes: BreadcrumbsRoute[];
-}): typeof NO_BREADCRUMB | BreadcrumbData => {
+   currentSection: string;
+   disableDefaults?: boolean;
+   excludePaths?: string[];
+   location: Location;
+   pathSection: string;
+   branches: BreadcrumbsRouteBranch[];
+ }): typeof NO_BREADCRUMB | BreadcrumbData => {
   let breadcrumb: BreadcrumbData | typeof NO_BREADCRUMB | undefined;
 
   // Check the optional `excludePaths` option in `options` to see if the
   // current path should not include a breadcrumb.
-  const getIsPathExcluded = (path: string): boolean => matchPath(pathSection, {
-    path,
-    exact: true,
-    strict: false,
-  }) != null;
+  const getIsPathExcluded = (path: string): boolean => matchPath(
+    {
+      path,
+      end: true,
+    },
+    pathSection,
+  ) != null;
 
   if (excludePaths && excludePaths.some(getIsPathExcluded)) {
     return NO_BREADCRUMB;
   }
 
   // Loop through the route array and see if the user has provided a custom breadcrumb.
-  routes.some(
-    ({ breadcrumb: userProvidedBreadcrumb, matchOptions, path, ...rest }) => {
-      if (!path) {
-        throw new Error(
-          'useBreadcrumbs: `path` must be provided in every route object',
-        );
+  branches.some(({ path, routesMeta }) => {
+    const { route } = routesMeta[routesMeta.length - 1];
+    let userProvidedBreadcrumb = route.breadcrumb;
+    // If the route is an index, but no breadcrumb is set,
+    // We try to use the breadcrumbs of the parent route instead
+    if (!userProvidedBreadcrumb && route.index) {
+      const parentMeta = routesMeta[routesMeta.length - 2];
+      if (parentMeta && parentMeta.route.breadcrumb) {
+        userProvidedBreadcrumb = parentMeta.route.breadcrumb;
       }
+    }
 
-      const match = matchPath(pathSection, {
-        ...(matchOptions || DEFAULT_MATCH_OPTIONS),
+    const { caseSensitive, props } = route;
+    const match = matchPath(
+      {
         path,
-      });
+        end: true,
+        caseSensitive,
+      },
+      pathSection,
+    );
 
-      // If user passed breadcrumb: null OR custom match options to suppress a breadcrumb
-      // we need to know NOT to add it to the matches array
-      // see: `if (breadcrumb !== NO_BREADCRUMB)` below.
-      if (
-        (match && userProvidedBreadcrumb === null)
-        || (!match && matchOptions)
-      ) {
+    // If user passed breadcrumb: null
+    // we need to know NOT to add it to the matches array
+    // see: `if (breadcrumb !== NO_BREADCRUMB)` below.
+    if (match && userProvidedBreadcrumb === null) {
+      breadcrumb = NO_BREADCRUMB;
+      return true;
+    }
+
+    if (match) {
+      // This covers the case where a user may be extending their react-router route
+      // config with breadcrumbs, but also does not want default breadcrumbs to be
+      // automatically generated (opt-in).
+      if (!userProvidedBreadcrumb && disableDefaults) {
         breadcrumb = NO_BREADCRUMB;
         return true;
       }
 
-      if (match) {
-        // This covers the case where a user may be extending their react-router route
-        // config with breadcrumbs, but also does not want default breadcrumbs to be
-        // automatically generated (opt-in).
-        if (!userProvidedBreadcrumb && disableDefaults) {
-          breadcrumb = NO_BREADCRUMB;
-          return true;
-        }
-
-        breadcrumb = render({
-          // Although we have a match, the user may be passing their react-router config object
-          // which we support. The route config object may not have a `breadcrumb` param specified.
-          // If this is the case, we should provide a default via `humanize`.
-          breadcrumb: userProvidedBreadcrumb || humanize(currentSection),
-          match,
-          location,
-          ...rest,
-        });
-        return true;
-      }
-      return false;
-    },
-  );
+      breadcrumb = render({
+        // Although we have a match, the user may be passing their react-router config object
+        // which we support. The route config object may not have a `breadcrumb` param specified.
+        // If this is the case, we should provide a default via `humanize`.
+        breadcrumb: userProvidedBreadcrumb || humanize(currentSection),
+        match,
+        location,
+        props,
+      });
+      return true;
+    }
+    return false;
+  });
 
   // User provided a breadcrumb prop, or we generated one above.
   if (breadcrumb) {
@@ -223,26 +372,25 @@ const getBreadcrumbMatch = ({
 };
 
 /**
- * Splits the pathname into sections, then search for matches in the routes
- * a user-provided breadcrumb OR a sensible default.
- */
+  * Splits the pathname into sections, then search for matches in the routes
+  * a user-provided breadcrumb OR a sensible default.
+  */
 export const getBreadcrumbs = ({
   routes,
   location,
   options = {},
 }: {
-  routes: BreadcrumbsRoute[];
-  location: Location;
-  options?: Options;
-}): BreadcrumbData[] => {
-  const matches: BreadcrumbData[] = [];
+   routes: BreadcrumbsRoute[];
+   location: Location;
+   options?: Options;
+ }): BreadcrumbData[] => {
   const { pathname } = location;
 
+  const branches = rankRouteBranches(flattenRoutes(routes));
+  const breadcrumbs: BreadcrumbData[] = [];
   pathname
     .split('?')[0]
-    // Split pathname into sections.
     .split('/')
-    // Reduce over the sections and call `getBreadcrumbMatch()` for each section.
     .reduce(
       (previousSection: string, currentSection: string, index: number) => {
         // Combine the last route section with the currentSection.
@@ -261,7 +409,7 @@ export const getBreadcrumbs = ({
           currentSection,
           location,
           pathSection,
-          routes,
+          branches,
           ...options,
         });
 
@@ -269,7 +417,7 @@ export const getBreadcrumbs = ({
         // unless the user has explicitly passed.
         // { path: x, breadcrumb: null } to disable.
         if (breadcrumb !== NO_BREADCRUMB) {
-          matches.push(breadcrumb);
+          breadcrumbs.push(breadcrumb);
         }
 
         return pathSection === '/' ? '' : pathSection;
@@ -277,29 +425,17 @@ export const getBreadcrumbs = ({
       '',
     );
 
-  return matches;
+  return breadcrumbs;
 };
 
 /**
- * Takes a route array and recursively flattens it IF there are
- * nested routes in the config.
- */
-const flattenRoutes = (routes: BreadcrumbsRoute[]): BreadcrumbsRoute[] => routes
-  .reduce((arr, route: BreadcrumbsRoute): BreadcrumbsRoute[] => {
-    if (route.routes) {
-      return arr.concat([route, ...flattenRoutes(route.routes)]);
-    }
-    return arr.concat(route);
-  }, [] as BreadcrumbsRoute[]);
-
-/**
- * Default hook function export.
- */
+  * Default hook function export.
+  */
 const useReactRouterBreadcrumbs = (
   routes?: BreadcrumbsRoute[],
   options?: Options,
 ): BreadcrumbData[] => getBreadcrumbs({
-  routes: flattenRoutes(routes || []),
+  routes: routes || [],
   location: useLocation(),
   options,
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -134,7 +134,7 @@ function flattenRoutes(
   parentPath = '',
 ): BreadcrumbsRouteBranch[] {
   routes.forEach((route, index) => {
-    if (!route.path && !route.index) {
+    if (typeof route.path !== 'string' && !route.index) {
       throw new Error(
         'useBreadcrumbs: `path` or `index` must be provided in every route object',
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,12 +1631,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.8.4":
   version: 7.14.0
   resolution: "@babel/runtime@npm:7.14.0"
   dependencies:
     regenerator-runtime: ^0.13.4
   checksum: ab6653f2f8ecdaebf36674894cef458a9d4f881dc007fdcd50a8261f5c6d9731e03fda2c17e32ecf0e6c779d69eb6cf49d68a48c780aaf07d5b572e8b7ef0508
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.7.6":
+  version: 7.16.0
+  resolution: "@babel/runtime@npm:7.16.0"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: 336e7f3ff6e7ecda749683c794eb5215410a2de1ec2845a39cbbd5eec870400aa68b9cc21dc44bf74d62e47682d0d0fb0600f263d218a23ba39f9cf6f1b7b54c
   languageName: node
   linkType: hard
 
@@ -2313,13 +2322,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/history@npm:*":
-  version: 4.7.8
-  resolution: "@types/history@npm:4.7.8"
-  checksum: 54020371a412e949d0a329cc325253f16daf5b33e2e485135d39d3b30d3f9a8e323b00ce1162da82387c8ecf0397a8da49ad36ab309f06284326c064092879c7
-  languageName: node
-  linkType: hard
-
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
   version: 2.0.3
   resolution: "@types/istanbul-lib-coverage@npm:2.0.3"
@@ -2407,16 +2409,6 @@ __metadata:
   dependencies:
     "@types/react": "*"
   checksum: 97df2088b5e1e1d3c6bf2ff6e4f8536bcd788cc7baeb49d912184923e4bee63d155d9821f15c4f36a6b89afe043f892d20015063a39a67aebf14dbc8998a1ccf
-  languageName: node
-  linkType: hard
-
-"@types/react-router@npm:^5.1.15":
-  version: 5.1.15
-  resolution: "@types/react-router@npm:5.1.15"
-  dependencies:
-    "@types/history": "*"
-    "@types/react": "*"
-  checksum: 6761d711ed42c4c3bc75c84aa486119d440bdab8025ef8602f189ad309d48f57a28dabfad3d2791133279fd8d65e962ad09a752eb54ff946a569e89ffc942fb6
   languageName: node
   linkType: hard
 
@@ -5179,26 +5171,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"history@npm:^4.9.0":
-  version: 4.10.1
-  resolution: "history@npm:4.10.1"
+"history@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "history@npm:5.1.0"
   dependencies:
-    "@babel/runtime": ^7.1.2
-    loose-envify: ^1.2.0
-    resolve-pathname: ^3.0.0
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
-    value-equal: ^1.0.1
-  checksum: 3b302b54c08f61f040a265ae9608c6dba88260179b9ddfe542042465ccf79e2ff19e792cb70c6e0240e80bc00b29aad5308d1f277815b1e95662bd5b819c625b
-  languageName: node
-  linkType: hard
-
-"hoist-non-react-statics@npm:^3.1.0":
-  version: 3.3.2
-  resolution: "hoist-non-react-statics@npm:3.3.2"
-  dependencies:
-    react-is: ^16.7.0
-  checksum: d3e3791d6e3a2741ce0ba38e878081dec49247ef22982a990c80941ee1f564ef16cd5a511bcc8c5e54f1ce8205535e0414ca5feea722c0690c80040be7ebf9df
+    "@babel/runtime": ^7.7.6
+  checksum: be7587c614078b6bc39bb3b8ae4da92f9d5d175bf1480c12119d056135eeb88c73589894451536be3d6a3ae250822cc5bf95a2cf5dca26d10b736ac70da0c56f
   languageName: node
   linkType: hard
 
@@ -5755,13 +5733,6 @@ __metadata:
   version: 1.0.2
   resolution: "is-windows@npm:1.0.2"
   checksum: dd1ed8339a28c68fb52f05931c832488dafc90063e53b97a69ead219a5584d7f3e6e564731c2f983962ff5403afeb05365d88ce9af34c8dae76a14911020d73a
-  languageName: node
-  linkType: hard
-
-"isarray@npm:0.0.1":
-  version: 0.0.1
-  resolution: "isarray@npm:0.0.1"
-  checksum: daeda3c23646200b0b464b7a9030d10008d7701fc6b7a1b45cafe42b4f4d2dde20835b56f19a49e04bb218245b7f7a2bcc6d0f696cff3711e4eddaa2031c611f
   languageName: node
   linkType: hard
 
@@ -6720,7 +6691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.2.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -6912,19 +6883,6 @@ __metadata:
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
   checksum: c3aeea46bc432e6ce69b86717e98fbb544e338abb5e3c93cfa196c427e3d5a4a6ee4f76e6931a9e424fb53e83451b90fc417ce7db04440a92d68369704ad11d1
-  languageName: node
-  linkType: hard
-
-"mini-create-react-context@npm:^0.4.0":
-  version: 0.4.1
-  resolution: "mini-create-react-context@npm:0.4.1"
-  dependencies:
-    "@babel/runtime": ^7.12.1
-    tiny-warning: ^1.0.3
-  peerDependencies:
-    prop-types: ^15.0.0
-    react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 26de37b293ecf37c3f858e7dfe545e652a0c177373985ec6059a54b22f1083c28b0c5b3a13910ad4bd61636a603db6f4c085752b56e007907799c9df9767f754
   languageName: node
   linkType: hard
 
@@ -7587,15 +7545,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "path-to-regexp@npm:1.8.0"
-  dependencies:
-    isarray: 0.0.1
-  checksum: 4c0d9aaf3fc55db0b2d9aab379856acbf4e437f2252bbc2a178aec9f707c8457f8084ea6243a80e0b37c8c1c20d23e918cd43e772a7e71142a8ad67af699686b
-  languageName: node
-  linkType: hard
-
 "path-type@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-type@npm:3.0.0"
@@ -7768,7 +7717,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.2, prop-types@npm:^15.7.0, prop-types@npm:^15.7.2":
+"prop-types@npm:^15.7.0, prop-types@npm:^15.7.2":
   version: 15.7.2
   resolution: "prop-types@npm:15.7.2"
   dependencies:
@@ -7869,30 +7818,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.6.0, react-is@npm:^16.7.0, react-is@npm:^16.8.1":
+"react-is@npm:^16.8.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 11bcf1267a314a522615f626f3ce3727a3a24cdbf61c4d452add3550a7875326669631326cfb1ba3e92b6f72244c32ffecf93ad21c0cad8455d3e169d0e3f060
   languageName: node
   linkType: hard
 
-"react-router@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "react-router@npm:5.2.0"
+"react-router@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "react-router@npm:6.0.1"
   dependencies:
-    "@babel/runtime": ^7.1.2
-    history: ^4.9.0
-    hoist-non-react-statics: ^3.1.0
-    loose-envify: ^1.3.1
-    mini-create-react-context: ^0.4.0
-    path-to-regexp: ^1.7.0
-    prop-types: ^15.6.2
-    react-is: ^16.6.0
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
+    history: ^5.1.0
   peerDependencies:
-    react: ">=15"
-  checksum: 4437eaa9bab02d46a7d6ea4915731c1f31642d6c3e3f7b9f951f5c6a9a73f35d4deb43a2d6b4be85f27816a20de96c3b9a9239f4b7e9136742106794ad20e95c
+    react: ">=16.8"
+  checksum: dfa23875d391f880f423ac044affacf4058438741c942abf692d53b78827acea27e590a98bc123cebeebdbb0f4573ea5c663b56c657dd441f1494ad762b1e502
   languageName: node
   linkType: hard
 
@@ -8187,13 +8127,6 @@ __metadata:
   dependencies:
     global-dirs: ^0.1.1
   checksum: 337635c53b22fcaf1fa2a49ef3da34167893582ab3200bc28f7f013cb0a617db03c7f21ab7b124a6a85e8725cade7f3fb0f4618e54fed2e507078ce8a4c5c58b
-  languageName: node
-  linkType: hard
-
-"resolve-pathname@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "resolve-pathname@npm:3.0.0"
-  checksum: 88ed8b3dd2b5cec68d35c319dc831cd879155da153208bb9c035f263cd9220fcf0af49158456871f64a181511f8e95c483c3700a958f4110f36e513b78cfd9f0
   languageName: node
   linkType: hard
 
@@ -9056,20 +8989,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.2":
-  version: 1.1.0
-  resolution: "tiny-invariant@npm:1.1.0"
-  checksum: 64318fbd77c451cfff23b57b9f3aef56594d9cea051a87dc538c9b371f97e8d474eaa2a7cbd60b8aa23f852393152495e8651b197607465fdf9c8ff134043b1b
-  languageName: node
-  linkType: hard
-
-"tiny-warning@npm:^1.0.0, tiny-warning@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "tiny-warning@npm:1.0.3"
-  checksum: 6cf9f66cb765b893976b8cd1c1310338861f30fb04d02ef2c8e0a748cbc2ed5acd8bb1954b78c15f640ad4116def67134d7d705f2a0c9bf27e6e2eb3e92bff29
-  languageName: node
-  linkType: hard
-
 "tmpl@npm:1.0.x":
   version: 1.0.4
   resolution: "tmpl@npm:1.0.4"
@@ -9420,7 +9339,6 @@ typescript@^4.3.2:
     "@rollup/plugin-typescript": ^8.2.1
     "@types/react": ^17.0.11
     "@types/react-dom": ^17.0.7
-    "@types/react-router": ^5.1.15
     "@typescript-eslint/eslint-plugin": ^4.26.1
     "@typescript-eslint/parser": ^4.26.1
     "@wojtekmaj/enzyme-adapter-react-17": ^0.6.1
@@ -9439,14 +9357,14 @@ typescript@^4.3.2:
     prop-types: ^15.7.2
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router: ^5.2.0
+    react-router: ^6.0.0
     rollup: ^2.51.1
     rollup-plugin-size: ^0.2.2
     rollup-plugin-terser: ^7.0.2
     typescript: ^4.3.2
   peerDependencies:
     react: ">=16.8"
-    react-router: ">=5.1.0"
+    react-router: ">=6.0.0"
   languageName: unknown
   linkType: soft
 
@@ -9502,13 +9420,6 @@ typescript@^4.3.2:
     spdx-correct: ^3.0.0
     spdx-expression-parse: ^3.0.0
   checksum: 940899bd4eacfa012ceecb10a5814ba0e8103da5243aa74d0d62f1f8a405efcd23e034fb7193e2d05b392870c53aabcb1f66439b062075cdcb28bc5d562a8ff6
-  languageName: node
-  linkType: hard
-
-"value-equal@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "value-equal@npm:1.0.1"
-  checksum: ae8cc7bbb2bebcaf78ecbf7669944cfc6e23f50361d0d97dc903abbfb9ce5111ce1dc5cb2575646db69636a84b2a3b224e2191088edc3442fb4669c2365af874
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Support React Router v6: #31 

## What are the changes?

- Compatible with Route Object: In React Router v6, [Route Object](https://reactrouter.com/docs/en/v6/examples/route-objects) can be used instead of configuration.
- Intelligent route sorting: Since React Router does not export the sorting algorithm, this is a simple copy and modification of it.
- Added some interface definitions.
- Removed `matchOptions`.

## How to migrate

Change Route Config to Route Object:

```js
// before:
const routeConfig = [
  {
    path: '/posts',
    component: Posts,
    breadcrumb: 'Posts',
  },
  {
    path: '/posts/:id',
    component: Post,
    breadcrumb: 'Post',
  },
];

// after:
const routes = [
  {
    path: 'posts',
    element: <Posts />,
    breadcrumb: 'Posts',
    children: [
      {
        path: ':id',
        element: <Post />,
        breadcrumb: 'Post',
      },
    ],
  },
];
```

Think about how to deal with matchOptions, In React Router v6, we have no concept of strict or exact matching, so you can only configure `caseSensitive` in the route object:

```js
const routes = [
  {
    path: 'posts',
    element: <Posts />,
    breadcrumb: 'Posts',
    caseSensitive: true,
  },
];
```

Try to use nested relative paths, otherwise your route-objects may be difficult to maintain:

```js
const routes = [
  {
    path: 'posts',
    element: <PostsLayout />,
    children: [
      {
        index: true,
        element: <Posts />,
        breadcrumb: 'Posts',
      },
      {
        path: ':id',
        element: <Post />,
        breadcrumb: 'Post',
      },
    ],
  },
];
```

`match.url` has been replaced by `match.pathname`, see [matchPath](https://reactrouter.com/docs/en/v6/api#matchpath), It is also recommended to just use `match.params` and `match.pathname`:

```js
const UserBreadcrumb = ({ match }) => {
  const { params } = match;
  return <div>{params.id}</div>;
};
```

**There may be other things that need attention, but I’m sorry I can only think of these for the time being.**

## Code Review

This change may be relatively large, and some things may require more careful consideration. For formal use, more detailed testing may be required.

Regarding why `matchRoutes` is not used, I mainly considered the following two points:

- Although matchRoutes now returns the original route object, But in its [function signature](https://reactrouter.com/docs/en/v6/api#matchroutes), it only returns RouteObject.
- For cases where routes are not passed in, special handling is required