### PR TITLE
Add a default formatter option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-react-router-breadcrumbs",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "A hook for displaying and setting breadcrumbs for react router",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -529,6 +529,23 @@ describe('use-react-router-breadcrumbs', () => {
         expect(breadcrumbs).toBe('One');
       });
     });
+
+    describe('defaultFormatter', () => {
+      it('should be used if a breadcrumb is not provided for a specific path', () => {
+        const routes = [
+          { path: '/one', breadcrumb: 'One' },
+          { path: '/one/two' },
+          { path: '/one/two/three_four' },
+        ];
+        const { breadcrumbs } = render({
+          pathname: '/one/two/three_four',
+          routes,
+          options: { defaultFormatter: (breadcrumb) => breadcrumb.replace(/two/g, 'changed') },
+        });
+
+        expect(breadcrumbs).toBe('Home / One / changed / three_four');
+      });
+    });
   });
 
   describe('Invalid route object', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -200,7 +200,7 @@ const NO_BREADCRUMB = Symbol('NO_BREADCRUMB');
  */
 export const humanize = (str: string): string => str
   .replace(/^[\s_]+|[\s_]+$/g, '')
-  .replace(/[_\s]+/g, ' ')
+  .replace(/[-_\s]+/g, ' ')
   .replace(/^[a-z]/, (m) => m.toUpperCase());
 
 /**
@@ -347,7 +347,8 @@ const getBreadcrumbMatch = ({
         // Although we have a match, the user may be passing their react-router config object
         // which we support. The route config object may not have a `breadcrumb` param specified.
         // If this is the case, we should provide a default via `humanize`.
-        breadcrumb: userProvidedBreadcrumb || humanize(currentSection),
+        breadcrumb: userProvidedBreadcrumb
+        || (defaultFormatter ? defaultFormatter(currentSection) : humanize(currentSection)),
         match: { ...match, route },
         location,
         props,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,7 @@ type Location = ReturnType<typeof useLocation>;
 export interface Options {
   disableDefaults?: boolean;
   excludePaths?: string[];
+  defaultFormatter?: (str: string) => string
 }
 
 export interface BreadcrumbMatch<ParamKey extends string = string> {
@@ -197,7 +198,7 @@ const NO_BREADCRUMB = Symbol('NO_BREADCRUMB');
  * we used to use the humanize-string package, but it added a lot of bundle
  * size and issues with compilation. This 4-liner seems to cover most cases.
  */
-const humanize = (str: string): string => str
+export const humanize = (str: string): string => str
   .replace(/^[\s_]+|[\s_]+$/g, '')
   .replace(/[_\s]+/g, ' ')
   .replace(/^[a-z]/, (m) => m.toUpperCase());
@@ -242,10 +243,12 @@ const getDefaultBreadcrumb = ({
   currentSection,
   location,
   pathSection,
+  defaultFormatter,
 }: {
   currentSection: string;
   location: Location;
   pathSection: string;
+  defaultFormatter?: (str: string) => string
 }): BreadcrumbData => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const match = matchPath(
@@ -257,7 +260,7 @@ const getDefaultBreadcrumb = ({
   )!;
 
   return render({
-    breadcrumb: humanize(currentSection),
+    breadcrumb: defaultFormatter ? defaultFormatter(currentSection) : humanize(currentSection),
     match,
     location,
   });
@@ -271,6 +274,7 @@ const getBreadcrumbMatch = ({
   currentSection,
   disableDefaults,
   excludePaths,
+  defaultFormatter,
   location,
   pathSection,
   branches,
@@ -278,6 +282,7 @@ const getBreadcrumbMatch = ({
   currentSection: string;
   disableDefaults?: boolean;
   excludePaths?: string[];
+  defaultFormatter?: (str: string) => string
   location: Location;
   pathSection: string;
   branches: BreadcrumbsRouteBranch[];
@@ -368,6 +373,7 @@ const getBreadcrumbMatch = ({
     // include a "Home" breadcrumb by default (can be overrode or disabled in config).
     currentSection: pathSection === '/' ? 'Home' : currentSection,
     location,
+    defaultFormatter,
   });
 };
 


### PR DESCRIPTION
While the `humanize` function does a good job there are some cases where I would like to have a different defaultFormatter without having to write out every single new route.  

This PR allows for that by adding a `defaultFormatter` to `useBreadCrumbs` when this option is provided we use it to format a breadcrumb instead of the internal `humanize` function.  Also I added `humanize` as an export so that users can still use it and add anything else on top of it if they see fit.