### PR TITLE
feat: Add compatability for declarative routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ const CustomPropsBreadcrumb = ({ someProp }) => (
 const routes = [
   { path: '/users/:userId', breadcrumb: DynamicUserBreadcrumb },
   { path: '/example', breadcrumb: 'Custom Example' },
-  { path: '/custom-props, breadcrumb: CustomPropsBreadcrumb, props: { someProp: 'Hi' }}, 
+  { path: '/custom-props, breadcrumb: CustomPropsBreadcrumb, props: { someProp: 'Hi' }},
 ];
 
 // map & render your breadcrumb components however you want.
@@ -125,6 +125,85 @@ const Breadcrumbs = () => {
     </>
   );
 };
+```
+
+For the above example...
+
+Pathname | Result
+--- | ---
+/users | Home / Users
+/users/1 | Home / Users / John
+/example | Home / Custom Example
+/custom-props | Home / Hi
+
+### Advanced (Declarative Routes)
+Same as the example above using Declarative Routing.
+
+```js
+import useBreadcrumbs from 'use-react-router-breadcrumbs';
+
+const userNamesById = { '1': 'John' }
+
+const DynamicUserBreadcrumb = ({ match }) => (
+  <span>{userNamesById[match.params.userId]}</span>
+);
+
+const CustomPropsBreadcrumb = ({ someProp }) => (
+  <span>{someProp}</span>
+);
+
+// define custom breadcrumbs for certain routes.
+// breadcumbs can be components or strings.
+
+// map & render your breadcrumb components however you want.
+const BreadcrumbTrail = (routes) => {
+  const breadcrumbs = useBreadcrumbs(routes);
+
+  return (
+    <>
+      {breadcrumbs.map(({
+        match,
+        breadcrumb
+      }) => (
+        <span key={match.pathname}>
+          <NavLink to={match.pathname}>{breadcrumb}</NavLink>
+        </span>
+      ))}
+    </>
+  );
+};
+
+const BuildAppRoutes = () => {
+  // Full declarative react router support. example: Element, children, Nested Routes
+  return (
+    <Route path='/users/:userId' breadcrumb={DynamicUserBreadcrumb} element={<ProfilePage/>} />
+    <Route path='/example' breadcrumb='Custom Example' >
+      <Route path='/' breadcrumb='Custom Example' >
+        <ExamplePage/>
+      </Route>
+    </Route>
+    <Route path='/custom-props' breadcrumb={CustomPropsBreadcrumb} props={ someProp: 'Hi' } >
+      <CustomPage/>
+    </Route>
+  )
+};
+
+const AppRouter = () => {
+  // You could use context to set app Routes and add the breadcrumbs somewhere deeper in the application layout.
+  const BreadCrumbs = buildBreadcrumbs(routes)
+  const appRoutes = buildAppRoutes();
+  const GenerateRoutes = () => {
+    return useRoutes(appRoutes);
+  }
+  return (
+    <React.StrictMode>
+      <Router>
+        <BreadCrumbs/>
+        <GenerateRoutes/>
+      </Router>
+    <React.StrictMode>
+  )
+}
 ```
 
 For the above example...

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Pathname | Result
 Same as the example above using Declarative Routing.
 
 ```js
-import useBreadcrumbs from 'use-react-router-breadcrumbs';
+import useBreadcrumbs, { createRoutesFromChildren } from 'use-react-router-breadcrumbs';
 
 const userNamesById = { '1': 'John' }
 
@@ -156,9 +156,7 @@ const CustomPropsBreadcrumb = ({ someProp }) => (
 // breadcumbs can be components or strings.
 
 // map & render your breadcrumb components however you want.
-const BreadcrumbTrail = (routes) => {
-  const breadcrumbs = useBreadcrumbs(routes);
-
+const BreadcrumbTrail = ({ breadCrumbs }) => {
   return (
     <>
       {breadcrumbs.map(({
@@ -173,7 +171,7 @@ const BreadcrumbTrail = (routes) => {
   );
 };
 
-const BuildAppRoutes = () => {
+const GenerateAppRoutes = () => {
   // Full declarative react router support. example: Element, children, Nested Routes
   return (
     <Route path='/users/:userId' breadcrumb={DynamicUserBreadcrumb} element={<ProfilePage/>} />
@@ -190,15 +188,14 @@ const BuildAppRoutes = () => {
 
 const AppRouter = () => {
   // You could use context to set app Routes and add the breadcrumbs somewhere deeper in the application layout.
-  const BreadCrumbs = buildBreadcrumbs(routes)
-  const appRoutes = buildAppRoutes();
-  const GenerateRoutes = () => {
-    return useRoutes(appRoutes);
-  }
+  const AppRoutes = GenerateAppRoutes();
+  const appRouteObjects = createRoutesFromChildren(AppRoutes);
+  const breadCrumbs = useBreadcrumbs(appRouteObjects)
+  const GeneratedRoutes = useRoutes(appRouteObjects);
   return (
     <React.StrictMode>
       <Router>
-        <BreadCrumbs/>
+        <BreadcrumbTrail breadCrumbs={breadCrumbs}/>
         <GenerateRoutes/>
       </Router>
     <React.StrictMode>

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,8 +3,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
-import { MemoryRouter as Router } from 'react-router';
-import useBreadcrumbs, { getBreadcrumbs } from './index.tsx';
+import { MemoryRouter as Router, Route, Routes } from 'react-router';
+import useBreadcrumbs, { getBreadcrumbs, createRoutesFromChildren } from './index.tsx';
 
 // imports to test compiled builds
 import useBreadcrumbsCompiledES, {
@@ -357,6 +357,28 @@ describe('use-react-router-breadcrumbs', () => {
       ];
       const { breadcrumbs } = render({ pathname: '/about', routes });
       expect(breadcrumbs).toBe('Home / About');
+    });
+
+    it('Should allow layout routes for declarative routes', () => {
+      const DeclarativeRoutes = (
+        <>
+          <Route path="/" element={<components.Layout />}>
+            <Route path="about" breadcrumb="About" />
+          </Route>
+          <Route index breadcrumb="Home" />
+          {false && <Route>unreached route</Route>}
+        </>
+      );
+      const routeObject = createRoutesFromChildren(DeclarativeRoutes);
+      const { breadcrumbs } = render({ pathname: '/about', routes: routeObject });
+      expect(breadcrumbs).toBe('Home / About');
+    });
+
+    it('Should throw if non route is used in Routes object', () => {
+      const DeclarativeRoutes = (
+        <div>div is not allowed as immediate child of Routes</div>
+      );
+      expect(() => { createRoutesFromChildren(DeclarativeRoutes); }).toThrow();
     });
 
     it('Should use the breadcrumb provided by parent if the index route dose not provide one', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -452,9 +452,7 @@ export default useReactRouterBreadcrumbs;
 
 // https://github.com/remix-run/react-router/blob/main/packages/react-router/index.tsx#L760
 
-///////////////////////////////////////////////////////////////////////////////
 // UTILS
-///////////////////////////////////////////////////////////////////////////////
 
 function invariant(cond: any, message: any) {
   if (!cond) throw new Error(message);
@@ -467,12 +465,12 @@ function invariant(cond: any, message: any) {
  *
  * @see https://reactrouter.com/docs/en/v6/api#createroutesfromchildren
  */
- export function createRoutesFromChildren(
-  children: React.ReactNode
+export function createRoutesFromChildren(
+  children: React.ReactNode,
 ): RouteObject[] {
-  let routes: RouteObject[] = [];
+  const routes: RouteObject[] = [];
 
-  React.Children.forEach(children, (element: string | number | boolean | {} | React.ReactElement<any, string | React.JSXElementConstructor<any>> | React.ReactPortal | null | undefined) => {
+  React.Children.forEach(children, (element) => {
     if (!React.isValidElement(element)) {
       // Ignore non-elements. This allows people to more easily inline
       // conditionals in their route config.
@@ -481,6 +479,7 @@ function invariant(cond: any, message: any) {
 
     if (element.type === React.Fragment) {
       // Transparently support React.Fragment and its children.
+      // eslint-disable-next-line prefer-spread
       routes.push.apply(
         routes,
         createRoutesFromChildren(element.props.children)
@@ -491,11 +490,11 @@ function invariant(cond: any, message: any) {
     invariant(
       element.type === Route,
       `[${
-        typeof element.type === "string" ? element.type : element.type.name
+        typeof element.type === 'string' ? element.type : element.type.name
       }] is not a <Route> component. All component children of <Routes> must be a <Route> or <React.Fragment>`
     );
 
-    let route: RouteObject = {
+    const route: RouteObject = {
       caseSensitive: element.props.caseSensitive,
       element: element.props.element,
       index: element.props.index,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -455,6 +455,7 @@ export default useReactRouterBreadcrumbs;
 
 // UTILS
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function invariant(cond: any, message: string): asserts cond {
   if (!cond) throw new Error(message);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -451,10 +451,11 @@ const useReactRouterBreadcrumbs = (
 export default useReactRouterBreadcrumbs;
 
 // https://github.com/remix-run/react-router/blob/main/packages/react-router/index.tsx#L760
+// The createRoutesFromChildren function has been modified to accept the breadcrumb route.
 
 // UTILS
 
-function invariant(cond: any, message: any) {
+function invariant(cond: any, message: string): asserts cond {
   if (!cond) throw new Error(message);
 }
 
@@ -467,9 +468,8 @@ function invariant(cond: any, message: any) {
  */
 export function createRoutesFromChildren(
   children: React.ReactNode,
-): RouteObject[] {
-  const routes: RouteObject[] = [];
-
+): BreadcrumbsRoute[] {
+  const routes: BreadcrumbsRoute[] = [];
   React.Children.forEach(children, (element) => {
     if (!React.isValidElement(element)) {
       // Ignore non-elements. This allows people to more easily inline
@@ -482,7 +482,7 @@ export function createRoutesFromChildren(
       // eslint-disable-next-line prefer-spread
       routes.push.apply(
         routes,
-        createRoutesFromChildren(element.props.children)
+        createRoutesFromChildren(element.props.children),
       );
       return;
     }
@@ -491,14 +491,15 @@ export function createRoutesFromChildren(
       element.type === Route,
       `[${
         typeof element.type === 'string' ? element.type : element.type.name
-      }] is not a <Route> component. All component children of <Routes> must be a <Route> or <React.Fragment>`
+      }] is not a <Route> component. All component children of <Routes> must be a <Route> or <React.Fragment>`,
     );
 
-    const route: RouteObject = {
+    const route: BreadcrumbsRoute = {
       caseSensitive: element.props.caseSensitive,
       element: element.props.element,
       index: element.props.index,
       path: element.props.path,
+      breadcrumb: element.props.breadcrumb,
     };
 
     if (element.props.children) {


### PR DESCRIPTION
This change adds the util function from react-router

`createRoutesFromChildren()`

It adds the breadcrumbs prop when recursing over children which allows the `createRoutesFromChildren` function to work for this library

The end result is that we can write declarative routes and then change them into object based routes.

Cheers, 
Let me know if there are any questions and concerns.

I have been using this change in a project in production for months with no issues.
resolves: #46

only item left in TODO:
`add test`