### PR TITLE
fix: typescript compiler for dynamic routing solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Pathname | Result
 Same as the example above using Declarative Routing.
 
 ```js
-import useBreadcrumbs, { createRoutesFromChildren } from 'use-react-router-breadcrumbs';
+import useBreadcrumbs, { createRoutesFromChildren, Route } from 'use-react-router-breadcrumbs';
 
 const userNamesById = { '1': 'John' }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
-import { MemoryRouter as Router, Route, Routes } from 'react-router';
+import { MemoryRouter as Router, Route } from 'react-router';
 import useBreadcrumbs, { getBreadcrumbs, createRoutesFromChildren } from './index.tsx';
 
 // imports to test compiled builds

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,9 @@ import {
   Params,
   PathPattern,
   Route,
+  PathRouteProps,
+  LayoutRouteProps,
+  IndexRouteProps,
 } from 'react-router';
 
 type Location = ReturnType<typeof useLocation>;
@@ -512,3 +515,13 @@ export function createRoutesFromChildren(
 
   return routes;
 }
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type BreadCrumb = { breadcrumb?: string | ((param: any) => JSX.Element) | JSX.Element | null };
+
+type BreadCrumbRouteType = (
+  _props: PathRouteProps | LayoutRouteProps | IndexRouteProps & BreadCrumb
+) => React.ReactElement | null;
+
+const BreadCrumbRoute: BreadCrumbRouteType = Route;
+
+export { BreadCrumbRoute as Route };


### PR DESCRIPTION
adds breadcrumb to the Route type from react router

#### Note: 
There may be a simpler way to add Type BreadCrumb to the type Route using an intersection:
but this is what I could get working.

I do not know how to update just the param of a function type in typescript.