### PR TITLE
feat: experimental support for nested route objects within components

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -341,37 +341,6 @@ describe('use-react-router-breadcrumbs', () => {
       expect(getByTextContent('Home / One / TwoCustom / ThreeCustom')).toBeTruthy();
     });
 
-    it('Should support nested route objects within child components', () => {
-      const routes = [
-        {
-          path: '/',
-          breadcrumb: 'Home',
-          children: [
-            {
-              path: 'users/*',
-              element: <components.NestedRouteObjects />,
-            },
-            {
-              path: 'admins/*',
-              element: <components.NestedRouteObjects />,
-            },
-          ],
-        },
-      ];
-
-      renderer({ pathname: '/users', routes });
-      expect(getByTextContent('Home / Users')).toBeTruthy();
-
-      renderer({ pathname: '/users/1', routes });
-      expect(getByTextContent('Home / Users / Mike')).toBeTruthy();
-
-      renderer({ pathname: '/users/1/edit', routes });
-      expect(getByTextContent('Home / Users / Mike / Edit')).toBeTruthy();
-
-      renderer({ pathname: '/admins/1/edit', routes });
-      expect(getByTextContent('Home / Admins / Mike / Edit')).toBeTruthy();
-    });
-
     it('Should allow layout routes', () => {
       const routes = [
         {
@@ -597,6 +566,64 @@ describe('use-react-router-breadcrumbs', () => {
 
         expect(getByTextContent('Home / One / changed / three_four')).toBeTruthy();
       });
+    });
+  });
+
+  describe('Route objects nested in components', () => {
+    it('should support nested route objects with breadcrumbs in child components', () => {
+      const routes = [
+        {
+          path: '/',
+          breadcrumb: 'Home',
+          children: [
+            {
+              path: 'users/*',
+              element: <components.NestedRouteObjects />,
+            },
+          ],
+        },
+      ];
+
+      renderer({ pathname: '/users/1/edit', routes });
+      expect(getByTextContent('Home / Users / Mike / Edit')).toBeTruthy();
+    });
+
+    it('should support lazy loading child components with breadcrumbs', () => {
+      const routes = [
+        {
+          path: '/',
+          breadcrumb: 'Home',
+          children: [
+            {
+              path: 'users/*',
+              element: <React.Suspense><components.NestedRouteObjects /></React.Suspense>,
+            },
+          ],
+        },
+      ];
+
+      renderer({ pathname: '/users/1/edit', routes });
+      expect(getByTextContent('Home / Users / Mike / Edit')).toBeTruthy();
+    });
+
+    it('should work normally if an element has no nested route objects and is a class component', () => {
+      const routes = [
+        {
+          path: '/',
+          breadcrumb: 'Home',
+          children: [
+            {
+              path: 'users/*',
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              element: <components.BreadcrumbClass />,
+            },
+          ],
+        },
+      ];
+
+      renderer({ pathname: '/users/1/edit', routes });
+      expect(getByTextContent('Home / Users / 1 / Edit')).toBeTruthy();
     });
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -176,6 +176,25 @@ function flattenRoutes(
     const path = joinPaths([parentPath, meta.relativePath]);
     const routesMeta = parentsMeta.concat(meta);
 
+    if (path.endsWith('/*')
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      && typeof route.element?.type === 'function'
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      && route.element?.type()?.props?.value?.matches[0]?.route?.children[0]?.breadcrumb) {
+      flattenRoutes(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        route.element?.type()?.props?.value?.matches[0]?.route?.children,
+        branches,
+        routesMeta,
+        path.slice(0, -2),
+      );
+
+      return branches;
+    }
+
     if (route.children && route.children.length > 0) {
       if (route.index) {
         throw new Error('useBreadcrumbs: Index route cannot have child routes');
@@ -188,6 +207,8 @@ function flattenRoutes(
       score: computeScore(path, route.index),
       routesMeta,
     });
+
+    return branches;
   });
   return branches;
 }


### PR DESCRIPTION
experimental support for #62 

this seems to work... but I'm not super happy with it because, well...
`route.element?.type()?.props?.value?.matches[0]?.route?.children[0]?.breadcrumb`

A lot of testing will be needed to make sure it doesn't cause any odd side-effects... at the end of the day, this might be a feature request for `react-router-dom` to provide some kind of way to get the entire route config context.