### PR TITLE
fix: make sure breadcrumb prop is available for all route types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -527,7 +527,7 @@ export function createRoutesFromChildren(
 type BreadCrumb = { breadcrumb?: string | ((param: any) => JSX.Element) | JSX.Element | null };
 
 type BreadCrumbRouteType = (
-  _props: PathRouteProps | LayoutRouteProps | IndexRouteProps & BreadCrumb
+  _props: (PathRouteProps | LayoutRouteProps | IndexRouteProps) & BreadCrumb
 ) => React.ReactElement | null;
 
 const BreadCrumbRoute: BreadCrumbRouteType = Route;


### PR DESCRIPTION
When trying to use the `breadcrumb` property on any other route type than the `Index` type (`Path` type in the following example ) I currently get:

`error TS2322: Type '{ children: Element; path: string; breadcrumb: null; }' is not assignable to type 'IntrinsicAttributes & (PathRouteProps | LayoutRouteProps | (IndexRouteProps & BreadCrumb))'.
  Property 'breadcrumb' does not exist on type 'IntrinsicAttributes & PathRouteProps'.`

Typescript version: 4.9.3
use-react-router-breadcrumbs version: 4.0.1
 
This type definition change seems to resolve the problem as far as I can tell. 
 